### PR TITLE
Fix #6 - Invalid Base DNs are not handled correctly

### DIFF
--- a/ldap_authentication/ldap_authentication.inc
+++ b/ldap_authentication/ldap_authentication.inc
@@ -654,9 +654,10 @@ function ldap_authentication_test_credentials($auth_conf, $sso_login, $authname,
       }
       if ($ldap_server->ldapErrorNumber()) {
         $authentication_result = LDAP_AUTHENTICATION_RESULT_FAIL_SERVER;
-        break;
       }
-      $authentication_result = LDAP_AUTHENTICATION_RESULT_FAIL_FIND;
+      else {
+        $authentication_result = LDAP_AUTHENTICATION_RESULT_FAIL_FIND;
+      }
       // Next server, please.
       continue;
     }


### PR DESCRIPTION
This PR allows the LDAP module to search other servers after there is an error on one server.